### PR TITLE
Support running without the mypy plugin

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -103,8 +103,7 @@ The ``trio_typing`` package provides:
   in determining the return type of ``await async_generator.yield_from_()``.)
 
 * A few types that are only useful with the mypy plugin: ``YieldType[T]``,
-  ``SendType[T]``, ``ArgsForCallable``, and the decorator
-  ``@takes_callable_and_args``.
+  ``SendType[T]``, and the decorator ``@takes_callable_and_args``.
 
 The ``trio_typing.plugin`` mypy plugin provides:
 
@@ -126,11 +125,12 @@ The ``trio_typing.plugin`` mypy plugin provides:
   and ultimately invoke ``fn(*args)``: just write
 
   ::
+      from mypy_extensions import VarArg
 
       @trio_typing.takes_callable_and_args
       def start_soon(
-          async_fn: Callable[[trio_typing.ArgsForCallable], Awaitable[T]],
-          *args: ArgsForCallable,
+          async_fn: Callable[[VarArg()], Awaitable[T]],
+          *args: Any,
           other_keywords: str = are_ok_too,
       ):
           # your implementation here
@@ -138,9 +138,28 @@ The ``trio_typing.plugin`` mypy plugin provides:
   ``start_soon(async_fn, *args)`` will raise an error if ``async_fn(*args)``
   would do so. You can also make the callable take some non-splatted
   arguments; the ``*args`` get inserted at whatever position in the
-  argument list you write ``ArgsForCallable``.
+  argument list you write ``VarArg()``.
 
-  Note: due to mypy limitations, we only support a maximum of 5
+  The above example will always fail when the plugin is not being
+  used. If you want to always pass in such cases, you can use a union::
+
+      @trio_typing.takes_callable_and_args
+      def start_soon(
+          async_fn: Union[
+              Callable[..., Awaitable[T]],
+              Callable[[VarArg()], Awaitable[T]],
+          ],
+          *args: Any,
+          other_keywords: str = are_ok_too,
+      ):
+          # your implementation here
+
+  Without the plugin, this type-checks fine (and allows inference of
+  ``T``), since any callable will match the ``Callable[...,
+  Awaitable[T]]`` option. With the plugin, the entire union will be
+  replaced with specific argument types.
+
+  Note: due to mypy limitations, we only support a maximum of 4
   positional arguments, and keyword arguments can't be passed in this way;
   ``nursery.start_soon(functools.partial(...))`` will pass the type checker
   but won't be able to actually check the argument types.
@@ -180,7 +199,7 @@ Limitations
 ~~~~~~~~~~~
 
 * Calls to variadic Trio functions like ``trio.run()``,
-  ``nursery.start_soon()``, and so on, only can type-check up to five
+  ``nursery.start_soon()``, and so on, only can type-check up to four
   positional arguments. (This number could be increased easily, but
   only at the cost of slower typechecking for everyone; mypy's current
   architecture requires that we generate overload sets initially for

--- a/README.rst
+++ b/README.rst
@@ -159,7 +159,7 @@ The ``trio_typing.plugin`` mypy plugin provides:
   Awaitable[T]]`` option. With the plugin, the entire union will be
   replaced with specific argument types.
 
-  Note: due to mypy limitations, we only support a maximum of 4
+  Note: due to mypy limitations, we only support a maximum of 5
   positional arguments, and keyword arguments can't be passed in this way;
   ``nursery.start_soon(functools.partial(...))`` will pass the type checker
   but won't be able to actually check the argument types.
@@ -199,7 +199,7 @@ Limitations
 ~~~~~~~~~~~
 
 * Calls to variadic Trio functions like ``trio.run()``,
-  ``nursery.start_soon()``, and so on, only can type-check up to four
+  ``nursery.start_soon()``, and so on, only can type-check up to five
   positional arguments. (This number could be increased easily, but
   only at the cost of slower typechecking for everyone; mypy's current
   architecture requires that we generate overload sets initially for

--- a/trio-stubs/__init__.pyi
+++ b/trio-stubs/__init__.pyi
@@ -23,8 +23,9 @@ from typing import (
     IO,
     overload,
 )
-from trio_typing import Nursery, TaskStatus, ArgsForCallable, takes_callable_and_args
+from trio_typing import Nursery, TaskStatus, takes_callable_and_args
 from typing_extensions import Protocol, Literal
+from mypy_extensions import VarArg
 import attr
 import signal
 import io
@@ -109,8 +110,8 @@ def current_effective_deadline() -> float: ...
 def current_time() -> float: ...
 @takes_callable_and_args
 def run(
-    afn: Callable[[ArgsForCallable], Awaitable[T]],
-    *args: ArgsForCallable,
+    afn: Union[Callable[..., Awaitable[T]], Callable[[VarArg()], Awaitable[T]]],
+    *args: Any,
     clock: trio.abc.Clock = ...,
     instruments: Sequence[trio.abc.Instrument] = ...,
     restrict_keyboard_interrupt_to_checkpoints: bool = ...,
@@ -194,18 +195,20 @@ class BlockingTrioPortal:
     def __init__(self, trio_token: Optional[trio.hazmat.TrioToken] = None) -> None: ...
     @takes_callable_and_args
     def run(
-        self, afn: Callable[[ArgsForCallable], Awaitable[T]], *args: ArgsForCallable
+        self,
+        afn: Union[Callable[..., Awaitable[T]], Callable[[VarArg()], Awaitable[T]]],
+        *args: Any,
     ) -> T: ...
     @takes_callable_and_args
     def run_sync(
-        self, fn: Callable[[ArgsForCallable], T], *args: ArgsForCallable
+        self, fn: Union[Callable[..., T], Callable[[VarArg()], T]], *args: Any
     ) -> T: ...
 
 def current_default_worker_thread_limiter() -> CapacityLimiter: ...
 @takes_callable_and_args
 async def run_sync_in_worker_thread(
-    sync_fn: Callable[[ArgsForCallable], T],
-    *args: ArgsForCallable,
+    sync_fn: Union[Callable[..., T], Callable[[VarArg()], T]],
+    *args: Any,
     cancellable: bool = False,
     limiter: Optional[CapacityLimiter] = None,
 ) -> T: ...

--- a/trio-stubs/hazmat.pyi
+++ b/trio-stubs/hazmat.pyi
@@ -15,7 +15,7 @@ from typing import (
     TypeVar,
     Tuple,
 )
-from trio_typing import Nursery, ArgsForCallable, takes_callable_and_args
+from trio_typing import Nursery, takes_callable_and_args
 import trio
 import outcome
 import contextvars
@@ -38,8 +38,8 @@ class TrioToken:
     @takes_callable_and_args
     def run_sync_soon(
         self,
-        sync_fn: Callable[[ArgsForCallable], None],
-        *args: ArgsForCallable,
+        sync_fn: Union[Callable[..., None], Callable[[VarArg()], None]],
+        *args: Any,
         idempotent: bool = False,
     ) -> None: ...
 
@@ -73,8 +73,10 @@ def current_trio_token() -> TrioToken: ...
 def reschedule(task: Task, next_send: outcome.Outcome[Any] = ...) -> None: ...
 @takes_callable_and_args
 def spawn_system_task(
-    async_fn: Callable[[ArgsForCallable], Awaitable[None]],
-    *args: ArgsForCallable,
+    async_fn: Union[
+        Callable[..., Awaitable[None]], Callable[[VarArg()], Awaitable[None]]
+    ],
+    *args: Any,
     name: object = ...,
 ) -> Task: ...
 def add_instrument(instrument: trio.abc.Instrument) -> None: ...

--- a/trio-stubs/hazmat.pyi
+++ b/trio-stubs/hazmat.pyi
@@ -16,6 +16,7 @@ from typing import (
     Tuple,
 )
 from trio_typing import Nursery, takes_callable_and_args
+from mypy_extensions import VarArg
 import trio
 import outcome
 import contextvars

--- a/trio_typing/__init__.py
+++ b/trio_typing/__init__.py
@@ -7,7 +7,6 @@ import trio as _trio
 from ._version import __version__
 
 __all__ = [
-    "ArgsForCallable",
     "takes_callable_and_args",
     "Nursery",
     "TaskStatus",
@@ -21,10 +20,6 @@ _T = _t.TypeVar("_T")
 _T_co = _t.TypeVar("_T_co", covariant=True)
 _T_co2 = _t.TypeVar("_T_co2", covariant=True)
 _T_contra = _t.TypeVar("_T_contra", contravariant=True)
-
-
-class ArgsForCallable:
-    pass
 
 
 def takes_callable_and_args(fn):

--- a/trio_typing/_tests/test-data/taskstatus.test
+++ b/trio_typing/_tests/test-data/taskstatus.test
@@ -26,3 +26,32 @@ async def parent() -> None:
         result2 = await nursery.start(child2, 10)
         reveal_type(result)  # E: Revealed type is 'builtins.int*'
         reveal_type(result2)  # E: Revealed type is 'None'
+
+[case testTaskStatus_NoPlugin]
+import trio
+from trio_typing import TaskStatus
+
+async def child(arg: int, *, task_status: TaskStatus[int]) -> None:
+    await trio.sleep(arg)
+    task_status.started("hi")  # E: Argument 1 to "started" of "TaskStatus" has incompatible type "str"; expected "int"
+    task_status.started()
+
+async def child2(
+    arg: int, *, task_status: TaskStatus[None] = trio.TASK_STATUS_IGNORED
+) -> None:
+    await trio.sleep(arg)
+    task_status.started()
+    await child(arg, task_status=task_status)  # E: Argument "task_status" to "child" has incompatible type "TaskStatus[None]"; expected "TaskStatus[int]"
+
+async def parent() -> None:
+    async with trio.open_nursery() as nursery:
+        nursery.start_soon(child, 10)  # E: Argument 1 to "start_soon" of "Nursery" has incompatible type "Callable[[int, NamedArg(TaskStatus[int], 'task_status')], Coroutine[Any, Any, None]]"; expected "Union[Callable[[], Awaitable[None]], Callable[[Any], Awaitable[None]], Callable[[Any, Any], Awaitable[None]], Callable[[Any, Any, Any], Awaitable[None]], Callable[[Any, Any, Any, Any], Awaitable[None]], Callable[[VarArg(Any)], Awaitable[None]]]"
+        nursery.start_soon(child2)
+        nursery.start_soon(child2, "hi")
+        nursery.start_soon(child2, 50)
+        await nursery.start(child)
+        await nursery.start(child, "hi")
+        result = await nursery.start(child, 10)
+        result2 = await nursery.start(child2, 10)
+        reveal_type(result)  # E: Revealed type is 'builtins.int*'
+        reveal_type(result2)  # E: Revealed type is 'None'

--- a/trio_typing/_tests/test-data/trio-basic.test
+++ b/trio_typing/_tests/test-data/trio-basic.test
@@ -21,8 +21,38 @@ async def sleep_sort(values: Sequence[float]) -> List[float]:
 
     return result
 
-trio.run(sleep_sort, (1, 3, 5, 2, 4), clock=trio.testing.MockClock(autojump_threshold=0))
+val = trio.run(sleep_sort, (1, 3, 5, 2, 4), clock=trio.testing.MockClock(autojump_threshold=0))
+reveal_type(val)  # E: Revealed type is 'builtins.list*[builtins.float]'
 trio.run(sleep_sort, ["hi", "there"])  # E: Argument 1 to "run" has incompatible type "Callable[[Sequence[float]], Coroutine[Any, Any, List[float]]]"; expected "Callable[[List[str]], Awaitable[List[float]]]"
+
+reveal_type(trio.Event().statistics().anything)  # E: Revealed type is 'Any'
+
+[case testTrioBasic_NoPlugin]
+import trio
+import trio.testing
+from typing import List, Sequence
+
+async def sleep_sort(values: Sequence[float]) -> List[float]:
+    result = []  # type: List[float]
+
+    async def worker(value: float) -> None:
+        await trio.sleep(value)
+        result.append(value)
+
+    async with trio.open_nursery() as nursery:
+        reveal_type(nursery)  # E: Revealed type is 'trio_typing.Nursery*'
+        reveal_type(nursery.cancel_scope)  # E: Revealed type is 'trio.CancelScope'
+        for value in values:
+            nursery.start_soon(worker, value)
+            nursery.start_soon(worker)
+            nursery.start_soon(worker, "hi")
+            nursery.start_soon(worker, value, value)
+
+    return result
+
+val = trio.run(sleep_sort, (1, 3, 5, 2, 4), clock=trio.testing.MockClock(autojump_threshold=0))
+reveal_type(val)  # E: Revealed type is 'builtins.list*[builtins.float]'
+trio.run(sleep_sort, ["hi", "there"])
 
 reveal_type(trio.Event().statistics().anything)  # E: Revealed type is 'Any'
 

--- a/trio_typing/_tests/test_typecheck.py
+++ b/trio_typing/_tests/test_typecheck.py
@@ -36,9 +36,11 @@ else:
                 options.python_version = (3, 6)
             else:
                 options.python_version = sys.version_info[:2]
-            options.plugins = ["trio_typing.plugin"]
-            # must specify something for config_file, else the plugins don't get loaded
-            options.config_file = "/dev/null"
+            if not testcase.name.endswith("_NoPlugin"):
+                options.plugins = ["trio_typing.plugin"]
+                # must specify something for config_file, else the
+                # plugins don't get loaded
+                options.config_file = "/dev/null"
             result = build.build(
                 sources=[BuildSource("main", None, src)], options=options
             )

--- a/trio_typing/plugin.py
+++ b/trio_typing/plugin.py
@@ -502,7 +502,7 @@ def takes_callable_and_args_callback(ctx: FunctionContext) -> Type:
         expanded_fns = []  # type: List[CallableType]
         type_var_defs = []  # type: List[TypeVarDef]
         type_var_types = []  # type: List[Type]
-        for arg_idx in range(1, 5):
+        for arg_idx in range(1, 6):
             arg_types = list(fn_type.arg_types)
             arg_types[callable_idx] = callable_ty.copy_modified(
                 arg_types=(

--- a/trio_typing/plugin.py
+++ b/trio_typing/plugin.py
@@ -410,8 +410,8 @@ def takes_callable_and_args_callback(ctx: FunctionContext) -> Type:
         @trio_typing.takes_callable_and_args
         def start_soon(
             self,
-            async_fn: Callable[[trio_typing.ArgsForCallable], None],
-            *args: trio_typing.ArgsForCallable,
+            async_fn: Callable[[VarArg()], None],
+            *args: Any,
         ) -> None: ...
 
     instead of::
@@ -457,56 +457,51 @@ def takes_callable_and_args_callback(ctx: FunctionContext) -> Type:
         fn_type = ctx.arg_types[0][0]  # type: CallableType
         callable_idx = -1  # index in function arguments of the callable
         callable_args_idx = -1  # index in callable arguments of the StarArgs
+        callable_ty = None  # type: Optional[CallableType]
         args_idx = -1  # index in function arguments of the StarArgs
 
         for idx, (kind, ty) in enumerate(zip(fn_type.arg_kinds, fn_type.arg_types)):
-            if (
-                isinstance(ty, Instance)
-                and ty.type.fullname() == "trio_typing.ArgsForCallable"
-            ):
-                if kind != ARG_STAR:
-                    raise ValueError(
-                        "ArgsForCallable must be used with a *args argument "
-                        "in the decorated function"
-                    )
+            if isinstance(ty, AnyType) and kind == ARG_STAR:
                 assert args_idx == -1
                 args_idx = idx
-            elif isinstance(ty, CallableType) and kind == ARG_POS:
+            elif isinstance(ty, (UnionType, CallableType)) and kind == ARG_POS:
+                # turn Union[Callable[..., T], Callable[[VarArg()], T]]
+                # into Callable[[VarArg()], T]
+                # (the union makes it not fail when the plugin is not being used)
+                if isinstance(ty, UnionType):
+                    for arm in ty.items:
+                        if (
+                            isinstance(arm, CallableType)
+                            and not arm.is_ellipsis_args
+                            and any(kind_ == ARG_STAR for kind_ in arm.arg_kinds)
+                        ):
+                            ty = arm
+                            break
+                    else:
+                        continue
+
                 for idx_, (kind_, ty_) in enumerate(zip(ty.arg_kinds, ty.arg_types)):
-                    if (
-                        isinstance(ty_, Instance)
-                        and ty_.type.fullname() == "trio_typing.ArgsForCallable"
-                    ):
-                        if kind != ARG_POS:
-                            raise ValueError(
-                                "ArgsForCallable must be used with a positional "
-                                "argument in the callable type that the decorated "
-                                "function takes"
-                            )
+                    if isinstance(ty_, AnyType) and kind_ == ARG_STAR:
                         if callable_idx != -1:
                             raise ValueError(
-                                "ArgsForCallable may only be used once as the type "
-                                "of an argument to a callable type that the "
-                                "decorated function takes"
+                                "decorated function may only take one callable "
+                                "that has an argument of type VarArg()"
                             )
                         callable_idx = idx
                         callable_args_idx = idx_
+                        callable_ty = cast(CallableType, ty)
         if args_idx == -1:
+            raise ValueError("decorated function must take *args: Any")
+        if callable_idx == -1 or callable_ty is None:
             raise ValueError(
-                "decorated function must take *args with type "
-                "trio_typing.ArgsForCallable"
-            )
-        if callable_idx == -1:
-            raise ValueError(
-                "decorated function must take a callable that has an "
-                "argument of type trio_typing.ArgsForCallable"
+                "decorated function must take a callable that has a "
+                "argument of type mypy_extensions.VarArg()"
             )
 
         expanded_fns = []  # type: List[CallableType]
         type_var_defs = []  # type: List[TypeVarDef]
         type_var_types = []  # type: List[Type]
         for arg_idx in range(1, 5):
-            callable_ty = cast(CallableType, fn_type.arg_types[callable_idx])
             arg_types = list(fn_type.arg_types)
             arg_types[callable_idx] = callable_ty.copy_modified(
                 arg_types=(

--- a/trio_typing/plugin.py
+++ b/trio_typing/plugin.py
@@ -489,7 +489,8 @@ def takes_callable_and_args_callback(ctx: FunctionContext) -> Type:
                             )
                         callable_idx = idx
                         callable_args_idx = idx_
-                        callable_ty = cast(CallableType, ty)
+                        callable_ty = ty
+
         if args_idx == -1:
             raise ValueError("decorated function must take *args: Any")
         if callable_idx == -1 or callable_ty is None:

--- a/trio_typing/plugin.py
+++ b/trio_typing/plugin.py
@@ -502,7 +502,7 @@ def takes_callable_and_args_callback(ctx: FunctionContext) -> Type:
         expanded_fns = []  # type: List[CallableType]
         type_var_defs = []  # type: List[TypeVarDef]
         type_var_types = []  # type: List[Type]
-        for arg_idx in range(1, 6):
+        for arg_idx in range(1, 7):  # provides overloads for 0 through 5 arguments
             arg_types = list(fn_type.arg_types)
             arg_types[callable_idx] = callable_ty.copy_modified(
                 arg_types=(


### PR DESCRIPTION
Calls to `@takes_callable_and_args` functions won't have the args type-checked without the plugin, but that's better than unconditionally failing.
In order to be more non-plugin-friendly, replace the `trio_typing.ArgsForCallable` marker type with `mypy_extensions.VarArg()`.
Add tests for reasonable behavior when the plugin is absent.
