### PR TITLE
Pin versions to fix CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,8 @@ matrix:
     - python: 3.5
     - python: 3.6
     - python: 3.7
-    - python: 3.8-dev
+    - python: 3.8
+    - python: nightly
 
 script:
   - ci/travis.sh

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ setup(
         "trio >= 0.12.1",
         # mypy can't be installed on PyPy due to its dependency
         # on typed-ast
-        "mypy >= 0.740; implementation_name == 'cpython'",
+        "mypy == 0.740; implementation_name == 'cpython'",
         "typing_extensions >= 3.7.4",
         "mypy_extensions >= 0.4.2",
     ],

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,2 +1,2 @@
 pytest
-attrs==19.1.0
+attrs>=19.2.0


### PR DESCRIPTION
- outcome and trio now require attrs 19.2 or later in order to support `eq=`.
- mypy 0.750 has some backwards-incompatible plugin API changes, so pin 0.740 for now