### PR TITLE
Allow clock= argument to be None

### DIFF
--- a/trio-stubs/__init__.pyi
+++ b/trio-stubs/__init__.pyi
@@ -167,7 +167,7 @@ def current_time() -> float: ...
 def run(
     afn: Union[Callable[..., Awaitable[T]], Callable[[VarArg()], Awaitable[T]]],
     *args: Any,
-    clock: trio.abc.Clock = ...,
+    clock: Optional[trio.abc.Clock] = ...,
     instruments: Sequence[trio.abc.Instrument] = ...,
     restrict_keyboard_interrupt_to_checkpoints: bool = ...,
 ) -> T: ...

--- a/trio-stubs/lowlevel.pyi
+++ b/trio-stubs/lowlevel.pyi
@@ -95,7 +95,7 @@ def start_guest_run(
     done_callback: Callable[[outcome.Outcome[T]], None],
     run_sync_soon_not_threadsafe: Callable[[Callable[[], None]], None] = ...,
     host_uses_signal_set_wakeup_fd: bool = ...,
-    clock: trio.abc.Clock = ...,
+    clock: Optional[trio.abc.Clock] = ...,
     instruments: Sequence[trio.abc.Instrument] = ...,
     restrict_keyboard_interrupt_to_checkpoints: bool = ...,
 ) -> None: ...


### PR DESCRIPTION
in trio.run() and trio.lowlevel.start_guest_run(), to match reality. Fixes #58.