### PR TITLE
Make Listener covariant w.r.t. the resource

### DIFF
--- a/trio-stubs/abc.pyi
+++ b/trio-stubs/abc.pyi
@@ -73,7 +73,7 @@ class HalfCloseableStream(Stream):
     @abstractmethod
     async def send_eof(self) -> None: ...
 
-_SomeResource = TypeVar("_SomeResource", bound=AsyncResource)
+_SomeResource = TypeVar("_SomeResource", bound=AsyncResource, covariant=True)
 
 class Listener(AsyncResource, Generic[_SomeResource]):
     @abstractmethod


### PR DESCRIPTION
This allows `Listener[SubTypeOfStream]` to be a subtype of `Listener[Stream]`. In this way the following function typechecks
```python
async def open_listener(
  port: int,
  should_use_ssl: bool
) -> Sequence[Listener[Stream]]:
  if should_use_ssl:
    return await open_ssl_over_tcp_listeners(port, ssl.create_default_context())
  else:
    return await open_tcp_listeners(port)
```