### PR TITLE
Fix typing for trio.abc.HostnameResolver getaddrinfo() and getnameinfo()

### DIFF
--- a/trio-stubs/abc.pyi
+++ b/trio-stubs/abc.pyi
@@ -27,7 +27,7 @@ class HostnameResolver(metaclass=ABCMeta):
     @abstractmethod
     async def getaddrinfo(
         self,
-        host: Union[bytes, str],
+        host: bytes,
         port: Union[str, int, None],
         family: int = ...,
         type: int = ...,
@@ -37,7 +37,7 @@ class HostnameResolver(metaclass=ABCMeta):
     @abstractmethod
     async def getnameinfo(
         self, sockaddr: Tuple[Any, ...], flags: int
-    ) -> Tuple[str, int]: ...
+    ) -> Tuple[str, str]: ...
 
 class SocketFactory(metaclass=ABCMeta):
     @abstractmethod


### PR DESCRIPTION
trio._socket.getaddrinfo() ensures a hostname is encoded into bytes before passing it as a parameter to trio.abc.HostnameResolver subclass instance overrides of getaddrinfo(). As such we should limit the type of the hostname parameter to bytes only.

trio._socket.getnameinfo() had its return type corrected in #56, and we should update the return type of HostnameResolver.getnameinfo() to match.