### PR TITLE
Fix incorrect `Callable[..., Awaitable]` annotations

### DIFF
--- a/trio-stubs/__init__.pyi
+++ b/trio-stubs/__init__.pyi
@@ -7,6 +7,7 @@ from typing import (
     Awaitable,
     Callable,
     ContextManager,
+    Coroutine,
     FrozenSet,
     Generic,
     Iterator,
@@ -119,15 +120,15 @@ class Nursery(_NotConstructible, metaclass=ABCMeta):
     def start_soon(
         self,
         async_fn: Union[
-            # List these explicitly instead of Callable[..., Awaitable[Any]]
+            # List these explicitly instead of Callable[..., Coroutine[Any, Any, Any]]
             # so that even without the plugin we catch cases of passing a
             # function with keyword-only arguments to start_soon().
-            Callable[[], Awaitable[Any]],
-            Callable[[Any], Awaitable[Any]],
-            Callable[[Any, Any], Awaitable[Any]],
-            Callable[[Any, Any, Any], Awaitable[Any]],
-            Callable[[Any, Any, Any, Any], Awaitable[Any]],
-            Callable[[VarArg()], Awaitable[Any]],
+            Callable[[], Coroutine[Any, Any, Any]],
+            Callable[[Any], Coroutine[Any, Any, Any]],
+            Callable[[Any, Any], Coroutine[Any, Any, Any]],
+            Callable[[Any, Any, Any], Coroutine[Any, Any, Any]],
+            Callable[[Any, Any, Any, Any], Coroutine[Any, Any, Any]],
+            Callable[[VarArg()], Coroutine[Any, Any, Any]],
         ],
         *args: Any,
         name: object = None,
@@ -136,24 +137,31 @@ class Nursery(_NotConstructible, metaclass=ABCMeta):
     async def start(
         self,
         async_fn: Union[
-            # List these explicitly instead of Callable[..., Awaitable[Any]]
+            # List these explicitly instead of Callable[..., Coroutine[Any, Any, Any]]
             # so that even without the plugin we can infer the return type
             # of start(), and fail when a function is passed that doesn't
             # accept task_status.
-            Callable[[NamedArg(TaskStatus[T], "task_status")], Awaitable[Any]],
-            Callable[[Any, NamedArg(TaskStatus[T], "task_status")], Awaitable[Any]],
             Callable[
-                [Any, Any, NamedArg(TaskStatus[T], "task_status")], Awaitable[Any]
+                [NamedArg(TaskStatus[T], "task_status")], Coroutine[Any, Any, Any]
             ],
             Callable[
-                [Any, Any, Any, NamedArg(TaskStatus[T], "task_status")], Awaitable[Any]
+                [Any, NamedArg(TaskStatus[T], "task_status")], Coroutine[Any, Any, Any]
+            ],
+            Callable[
+                [Any, Any, NamedArg(TaskStatus[T], "task_status")],
+                Coroutine[Any, Any, Any],
+            ],
+            Callable[
+                [Any, Any, Any, NamedArg(TaskStatus[T], "task_status")],
+                Coroutine[Any, Any, Any],
             ],
             Callable[
                 [Any, Any, Any, Any, NamedArg(TaskStatus[T], "task_status")],
-                Awaitable[Any],
+                Coroutine[Any, Any, Any],
             ],
             Callable[
-                [VarArg(), NamedArg(TaskStatus[T], "task_status")], Awaitable[Any]
+                [VarArg(), NamedArg(TaskStatus[T], "task_status")],
+                Coroutine[Any, Any, Any],
             ],
         ],
         *args: Any,
@@ -556,7 +564,7 @@ class Path(pathlib.PurePath):
 T_resource = TypeVar("T_resource", bound=trio.abc.AsyncResource)
 
 async def serve_listeners(
-    handler: Callable[[T_resource], Awaitable[Any]],
+    handler: Callable[[T_resource], Coroutine[Any, Any, Any]],
     listeners: Sequence[trio.abc.Listener[T_resource]],
     *,
     handler_nursery: Optional[Nursery] = None,
@@ -577,7 +585,7 @@ async def open_tcp_listeners(
     port: int, *, host: Optional[AnyStr] = None, backlog: Optional[int] = None
 ) -> Sequence[SocketListener]: ...
 async def serve_tcp(
-    handler: Callable[[SocketStream], Awaitable[Any]],
+    handler: Callable[[SocketStream], Coroutine[Any, Any, Any]],
     port: int,
     *,
     host: Optional[AnyStr] = None,
@@ -607,7 +615,7 @@ async def open_ssl_over_tcp_listeners(
     backlog: Optional[int] = None,
 ) -> Sequence[trio.SSLListener]: ...
 async def serve_ssl_over_tcp(
-    handler: Callable[[trio.SSLStream], Awaitable[Any]],
+    handler: Callable[[trio.SSLStream], Coroutine[Any, Any, Any]],
     port: int,
     ssl_context: ssl.SSLContext,
     *,

--- a/trio-stubs/lowlevel.pyi
+++ b/trio-stubs/lowlevel.pyi
@@ -77,7 +77,8 @@ def reschedule(task: Task, next_send: outcome.Outcome[Any] = ...) -> None: ...
 @takes_callable_and_args
 def spawn_system_task(
     async_fn: Union[
-        Callable[..., Awaitable[Any]], Callable[[VarArg()], Awaitable[Any]]
+        Callable[..., Coroutine[Any, Any, Any]],
+        Callable[[VarArg()], Coroutine[Any, Any, Any]],
     ],
     *args: Any,
     name: object = ...,

--- a/trio_typing/_tests/test-data/taskstatus.test
+++ b/trio_typing/_tests/test-data/taskstatus.test
@@ -16,12 +16,12 @@ async def child2(
 
 async def parent() -> None:
     async with trio.open_nursery() as nursery:
-        nursery.start_soon(child, 10)  # E: Argument 1 to "start_soon" of "Nursery" has incompatible type "Callable[[int, NamedArg(TaskStatus[int], 'task_status')], Coroutine[Any, Any, None]]"; expected "Callable[[int], Awaitable[Any]]"
-        nursery.start_soon(child2)  # E: Argument 1 to "start_soon" of "Nursery" has incompatible type "Callable[[int, DefaultNamedArg(TaskStatus[None], 'task_status')], Coroutine[Any, Any, None]]"; expected "Callable[[], Awaitable[Any]]"
-        nursery.start_soon(child2, "hi")  # E: Argument 1 to "start_soon" of "Nursery" has incompatible type "Callable[[int, DefaultNamedArg(TaskStatus[None], 'task_status')], Coroutine[Any, Any, None]]"; expected "Callable[[str], Awaitable[Any]]"
+        nursery.start_soon(child, 10)  # E: Argument 1 to "start_soon" of "Nursery" has incompatible type "Callable[[int, NamedArg(TaskStatus[int], 'task_status')], Coroutine[Any, Any, None]]"; expected "Callable[[int], Coroutine[Any, Any, Any]]"
+        nursery.start_soon(child2)  # E: Argument 1 to "start_soon" of "Nursery" has incompatible type "Callable[[int, DefaultNamedArg(TaskStatus[None], 'task_status')], Coroutine[Any, Any, None]]"; expected "Callable[[], Coroutine[Any, Any, Any]]"
+        nursery.start_soon(child2, "hi")  # E: Argument 1 to "start_soon" of "Nursery" has incompatible type "Callable[[int, DefaultNamedArg(TaskStatus[None], 'task_status')], Coroutine[Any, Any, None]]"; expected "Callable[[str], Coroutine[Any, Any, Any]]"
         nursery.start_soon(child2, 50)
-        await nursery.start(child)  # E: Argument 1 to "start" of "Nursery" has incompatible type "Callable[[int, NamedArg(TaskStatus[int], 'task_status')], Coroutine[Any, Any, None]]"; expected "Callable[[NamedArg(TaskStatus[<nothing>], 'task_status')], Awaitable[Any]]"
-        await nursery.start(child, "hi")  # E: Argument 1 to "start" of "Nursery" has incompatible type "Callable[[int, NamedArg(TaskStatus[int], 'task_status')], Coroutine[Any, Any, None]]"; expected "Callable[[str, NamedArg(TaskStatus[int], 'task_status')], Awaitable[Any]]"
+        await nursery.start(child)  # E: Argument 1 to "start" of "Nursery" has incompatible type "Callable[[int, NamedArg(TaskStatus[int], 'task_status')], Coroutine[Any, Any, None]]"; expected "Callable[[NamedArg(TaskStatus[<nothing>], 'task_status')], Coroutine[Any, Any, Any]]"
+        await nursery.start(child, "hi")  # E: Argument 1 to "start" of "Nursery" has incompatible type "Callable[[int, NamedArg(TaskStatus[int], 'task_status')], Coroutine[Any, Any, None]]"; expected "Callable[[str, NamedArg(TaskStatus[int], 'task_status')], Coroutine[Any, Any, Any]]"
         result = await nursery.start(child, 10)
         result2 = await nursery.start(child2, 10)
         reveal_type(result)  # N: Revealed type is "builtins.int*"
@@ -45,7 +45,7 @@ async def child2(
 
 async def parent() -> None:
     async with trio.open_nursery() as nursery:
-        nursery.start_soon(child, 10)  # E: Argument 1 to "start_soon" of "Nursery" has incompatible type "Callable[[int, NamedArg(TaskStatus[int], 'task_status')], Coroutine[Any, Any, None]]"; expected "Union[Callable[[], Awaitable[Any]], Callable[[Any], Awaitable[Any]], Callable[[Any, Any], Awaitable[Any]], Callable[[Any, Any, Any], Awaitable[Any]], Callable[[Any, Any, Any, Any], Awaitable[Any]], Callable[[VarArg(Any)], Awaitable[Any]]]"
+        nursery.start_soon(child, 10)  # E: Argument 1 to "start_soon" of "Nursery" has incompatible type "Callable[[int, NamedArg(TaskStatus[int], 'task_status')], Coroutine[Any, Any, None]]"; expected "Union[Callable[[], Coroutine[Any, Any, Any]], Callable[[Any], Coroutine[Any, Any, Any]], Callable[[Any, Any], Coroutine[Any, Any, Any]], Callable[[Any, Any, Any], Coroutine[Any, Any, Any]], Callable[[Any, Any, Any, Any], Coroutine[Any, Any, Any]], Callable[[VarArg(Any)], Coroutine[Any, Any, Any]]]"
         nursery.start_soon(child2)
         nursery.start_soon(child2, "hi")
         nursery.start_soon(child2, 50)

--- a/trio_typing/_tests/test-data/trio-basic.test
+++ b/trio_typing/_tests/test-data/trio-basic.test
@@ -15,9 +15,9 @@ async def sleep_sort(values: Sequence[float]) -> List[float]:
         reveal_type(nursery.cancel_scope)  # N: Revealed type is "trio.CancelScope"
         for value in values:
             nursery.start_soon(worker, value)
-            nursery.start_soon(worker)  # E: Argument 1 to "start_soon" of "Nursery" has incompatible type "Callable[[float], Coroutine[Any, Any, None]]"; expected "Callable[[], Awaitable[Any]]"
-            nursery.start_soon(worker, "hi")  # E: Argument 1 to "start_soon" of "Nursery" has incompatible type "Callable[[float], Coroutine[Any, Any, None]]"; expected "Callable[[str], Awaitable[Any]]"
-            nursery.start_soon(worker, value, value)  # E: Argument 1 to "start_soon" of "Nursery" has incompatible type "Callable[[float], Coroutine[Any, Any, None]]"; expected "Callable[[float, float], Awaitable[Any]]"
+            nursery.start_soon(worker)  # E: Argument 1 to "start_soon" of "Nursery" has incompatible type "Callable[[float], Coroutine[Any, Any, None]]"; expected "Callable[[], Coroutine[Any, Any, Any]]"
+            nursery.start_soon(worker, "hi")  # E: Argument 1 to "start_soon" of "Nursery" has incompatible type "Callable[[float], Coroutine[Any, Any, None]]"; expected "Callable[[str], Coroutine[Any, Any, Any]]"
+            nursery.start_soon(worker, value, value)  # E: Argument 1 to "start_soon" of "Nursery" has incompatible type "Callable[[float], Coroutine[Any, Any, None]]"; expected "Callable[[float, float], Coroutine[Any, Any, Any]]"
 
     return result
 


### PR DESCRIPTION
Hi!

Various functions that require a callable that returns a coroutine are incorrectly annotated as able to accept callables that return non-coroutine awaitables.

For example, the following tests currently pass type checking but raise `TypeError`s at runtime:

```python
from typing import Any
from typing import Awaitable
from typing import Generator

import pytest
import trio
from trio import TASK_STATUS_IGNORED
from trio import Event

from trio_typing import TaskStatus

pytestmark = pytest.mark.trio


class CoroFuncLike:
    """A single-use callable that returns a non-coroutine awaitable."""

    def __init__(self) -> None:
        self.done = Event()

    def __call__(
        self, *, task_status: TaskStatus = TASK_STATUS_IGNORED
    ) -> Awaitable[None]:
        self._task_status = task_status
        return self

    def __await__(self) -> Generator[Any, None, None]:
        return self.__wait().__await__()

    async def __wait(self) -> None:
        self._task_status.started()
        await trio.sleep(0)
        self.done.set()


async def test_nursery_start_soon_non_corofunc() -> None:
    async with trio.open_nursery() as task_group:
        coro_func_like = CoroFuncLike()
        task_group.start_soon(coro_func_like)
        await coro_func_like.done.wait()


async def test_nursery_start_non_corofunc() -> None:
    async with trio.open_nursery() as task_group:
        coro_func_like = CoroFuncLike()
        await task_group.start(coro_func_like)
        await coro_func_like.done.wait()


async def test_spawn_system_task_non_corofunc() -> None:
    coro_func_like = CoroFuncLike()
    trio.lowlevel.spawn_system_task(coro_func_like)
```

This PR makes these tests correctly fail to type check.

Regarding `serve_listeners`: according to `serve_listeners`'s documentation, its `handler` argument gets passed to `Nursery.start_soon`, so `Callable[..., Awaitable]` is not acceptable for it either. (At runtime, however, it seems like `Callable[..., Awaitable]` would work, as `serve_listeners`'s actual implementation is subtly different than its documentation states---see `trio._highlevel_serve_listeners._run_handler`.)

`serve_tcp` and `serve_ssl_over_tcp`'s `handler` arguments are just passed to `serve_listeners`, so the same limitation applies to them too.