### PR TITLE
Remove python 3.6 from test matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,6 @@ jobs:
       fail-fast: false
       matrix:
         python:
-          - '3.6'
           - '3.7'
           - '3.8'
           - '3.9'


### PR DESCRIPTION
Python 3.6 has reached EOL and trio now requires at least python 3.7. Python 3.6 is also no longer supported on Github Actions for the latest ubuntu version, see https://github.com/actions/setup-python/issues/543