### PR TITLE
Fix `open_signal_receiver` misannotation

### DIFF
--- a/trio-stubs/__init__.pyi
+++ b/trio-stubs/__init__.pyi
@@ -290,7 +290,7 @@ class open_memory_channel(Tuple[MemorySendChannel[T], MemoryReceiveChannel[T]]):
 # _signals
 def open_signal_receiver(
     *signals: signal.Signals,
-) -> ContextManager[AsyncIterator[signal.Signals]]: ...
+) -> ContextManager[AsyncIterator[int]]: ...
 
 # _highlevel_socket
 class SocketStream(trio.abc.HalfCloseableStream):


### PR DESCRIPTION
Hi!

I believe `open_signal_receiver`'s return type is misannotated. For example:

```python
import signal
from typing import reveal_type

import trio


async def main() -> None:
    with trio.open_signal_receiver(signal.SIGINT, signal.SIGTERM) as signal_receiver:
        async for signum in signal_receiver:
            reveal_type(signum)  # int at runtime, but signal.Signals during type checking!
            print(signum.name)  # passes type checking, but AttributeError at runtime.
            raise SystemExit(1)


if __name__ == "__main__":
    trio.run(main)
```