### PR TITLE
Fix `TaskStatus.started` being type-unsafe when not using the mypy plugin

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -139,10 +139,6 @@ The ``trio_typing.plugin`` mypy plugin provides:
   file object in binary mode and ``await trio.open_file("bar")`` returns
   an async file object in text mode
 
-* Signature checking for ``task_status.started()`` with no arguments,
-  so it raises an error if the ``task_status`` object is not of type
-  ``TaskStatus[None]``
-
 * Boilerplate reduction for functions that take parameters ``(fn, *args)``
   and ultimately invoke ``fn(*args)``: just write::
 

--- a/trio_typing/__init__.pyi
+++ b/trio_typing/__init__.pyi
@@ -38,7 +38,10 @@ def takes_callable_and_args(fn: T) -> T:
     return fn
 
 class TaskStatus(Protocol[T_contra]):
-    def started(self, value: T_contra = ...) -> None: ...
+    @overload
+    def started(self: TaskStatus[None]) -> None: ...
+    @overload
+    def started(self, value: T_contra) -> None: ...
 
 if sys.version_info >= (3, 6):
     from typing import AsyncGenerator as AsyncGenerator

--- a/trio_typing/_tests/test-data/taskstatus.test
+++ b/trio_typing/_tests/test-data/taskstatus.test
@@ -5,13 +5,14 @@ from trio_typing import TaskStatus
 async def child(arg: int, *, task_status: TaskStatus[int]) -> None:
     await trio.sleep(arg)
     task_status.started("hi")  # E: Argument 1 to "started" of "TaskStatus" has incompatible type "str"; expected "int"
-    task_status.started()  # E: TaskStatus.started() requires an argument for types other than TaskStatus[None]
+    task_status.started()  # E: Missing positional argument "value" in call to "started" of "TaskStatus"
 
 async def child2(
     arg: int, *, task_status: TaskStatus[None] = trio.TASK_STATUS_IGNORED
 ) -> None:
     await trio.sleep(arg)
     task_status.started()
+    task_status.started(None)
     await child(arg, task_status=task_status)  # E: Argument "task_status" to "child" has incompatible type "TaskStatus[None]"; expected "TaskStatus[int]"
 
 async def parent() -> None:
@@ -34,13 +35,14 @@ from trio_typing import TaskStatus
 async def child(arg: int, *, task_status: TaskStatus[int]) -> None:
     await trio.sleep(arg)
     task_status.started("hi")  # E: Argument 1 to "started" of "TaskStatus" has incompatible type "str"; expected "int"
-    task_status.started()
+    task_status.started()  # E: Missing positional argument "value" in call to "started" of "TaskStatus"
 
 async def child2(
     arg: int, *, task_status: TaskStatus[None] = trio.TASK_STATUS_IGNORED
 ) -> None:
     await trio.sleep(arg)
     task_status.started()
+    task_status.started(None)
     await child(arg, task_status=task_status)  # E: Argument "task_status" to "child" has incompatible type "TaskStatus[None]"; expected "TaskStatus[int]"
 
 async def parent() -> None:

--- a/trio_typing/plugin.py
+++ b/trio_typing/plugin.py
@@ -51,13 +51,6 @@ class TrioPlugin(Plugin):
             return yield_from_callback
         return None
 
-    def get_method_hook(
-        self, fullname: str
-    ) -> Optional[Callable[[MethodContext], Type]]:
-        if fullname == "trio_typing.TaskStatus.started":
-            return started_callback
-        return None
-
 
 def args_invariant_decorator_callback(ctx: FunctionContext) -> Type:
     """Infer a better return type for @asynccontextmanager,
@@ -320,25 +313,6 @@ def yield_from_callback(ctx: FunctionContext) -> Type:
             supertype_label="expected iterable type",
         )
 
-    return ctx.default_return_type
-
-
-def started_callback(ctx: MethodContext) -> Type:
-    """Raise an error if task_status.started() is called without an argument
-    and the TaskStatus is not declared to accept a result of type None.
-    """
-    self_type = get_proper_type(ctx.type)
-    if (
-        (not ctx.arg_types or not ctx.arg_types[0])
-        and isinstance(self_type, Instance)
-        and self_type.args
-        and not isinstance(get_proper_type(self_type.args[0]), NoneTyp)
-    ):
-        ctx.api.fail(
-            "TaskStatus.started() requires an argument for types other than "
-            "TaskStatus[None]",
-            ctx.context,
-        )
     return ctx.default_return_type
 
 


### PR DESCRIPTION
closes #80!