### PR TITLE
Add strict_exception_groups parameter to start_guest_run()

### DIFF
--- a/trio-stubs/lowlevel.pyi
+++ b/trio-stubs/lowlevel.pyi
@@ -102,6 +102,7 @@ def start_guest_run(
     clock: Optional[trio.abc.Clock] = ...,
     instruments: Sequence[trio.abc.Instrument] = ...,
     restrict_keyboard_interrupt_to_checkpoints: bool = ...,
+    strict_exception_groups: bool = ...,
 ) -> None: ...
 
 # kqueue only


### PR DESCRIPTION
#76 added this for `trio.run()`, but not `trio.lowlevel.start_guest_run()`. 