### PR TITLE
Require mypy < 1.7.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ setup(
     ],
     extras_require={
         "mypy": [  # can't be installed on PyPy due to its dependency on typed-ast
-            "mypy >= 0.920",
+            "mypy >= 0.920,<1.7.10",
         ],
     },
     keywords=["async", "trio", "mypy"],


### PR DESCRIPTION
As per #90, this PR makes the project require `mypy < 1.7.0`