### PR TITLE
Add 'abandon_on_cancel' to to_thread.run_sync

### DIFF
--- a/trio-stubs/to_thread.pyi
+++ b/trio-stubs/to_thread.pyi
@@ -10,6 +10,6 @@ def current_default_thread_limiter() -> trio.CapacityLimiter: ...
 async def run_sync(
     sync_fn: Union[Callable[..., _T], Callable[[VarArg()], _T]],
     *args: Any,
-    cancellable: bool = False,
+    abandon_on_cancel: bool = False,
     limiter: Optional[trio.CapacityLimiter] = None,
 ) -> _T: ...


### PR DESCRIPTION
A new parameter name was added
https://trio.readthedocs.io/en/stable/history.html#id15